### PR TITLE
Add Howtos for dirname, basename and symlink resolving

### DIFF
--- a/Zsh-Native-Scripting-Handbook.adoc
+++ b/Zsh-Native-Scripting-Handbook.adoc
@@ -103,7 +103,7 @@ second double-quoting isn't actually needed.
 local dirname="${PWD:h}"
 local basename="${PWD:t}"
 ----
-Read more about [history modifiers](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers).
+Read more about link:http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers[history modifiers].
 
 [#skipping-grep]
 ### Skipping grep

--- a/Zsh-Native-Scripting-Handbook.adoc
+++ b/Zsh-Native-Scripting-Handbook.adoc
@@ -94,10 +94,21 @@ outside quoting of `${(f@)...}` substitution works as if it was also separately
 applied to `$(command ...)` (or to `$(<file-path)`) inner substitution, so the
 second double-quoting isn't actually needed.
 
+[#skipping-dirname-basename]
+### Skipping dirname basename
+
+`dirname` and `basename` can be skipped by:
+[source,zsh]
+----
+local dirname="${PWD:h}"
+local basename="${PWD:t}"
+----
+Read more about [history modifiers](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers).
+
 [#skipping-grep]
 ### Skipping grep
 
-[source,none]
+[source,zsh]
 ----
 declare -a lines; lines=( "${(@f)"$(<path/file)"}" )
 declare -a grepped; grepped=( ${(M)lines:#*query*} )

--- a/Zsh-Native-Scripting-Handbook.adoc
+++ b/Zsh-Native-Scripting-Handbook.adoc
@@ -105,6 +105,15 @@ local basename="${PWD:t}"
 ----
 Read more about link:http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers[history modifiers].
 
+[#resolve-symlinks]
+### Resolve Symlinks
+
+Symbolic links can be turned into an absolute path with:
+[source,zsh]
+----
+local absolute_path="${PWD:A}
+----
+
 [#skipping-grep]
 ### Skipping grep
 


### PR DESCRIPTION
This adds some pretty basic stuff, but it worth a mention, IMHO. Adds howtos for skipping `dirname`, `basename` and resolving symlinks.