### PR TITLE
Update fpath advise in Zsh-Plugin-Standard.adoc

### DIFF
--- a/Zsh-Plugin-Standard.adoc
+++ b/Zsh-Plugin-Standard.adoc
@@ -14,15 +14,16 @@ in a particular way.
 
 At a simple level, a plugin:
 
-1. Has its directory added to `$fpath`
-  (link:http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions[Zsh
-  documentation]). This is being done either by a plugin manager or by the
-  plugin itself (see link:#indicator[5th section] for more information).
-
-2. Has its first `\*.plugin.zsh` file sourced (or `*.zsh`, `init.zsh`, `*.sh`,
+1. Has its first `\*.plugin.zsh` file sourced (or `*.zsh`, `init.zsh`, `*.sh`,
    these are non-standard).
 
-The first point allows plugins to provide completions and functions that are
+2. If it adds any of its subdirectories to `$fpath`, then those subdirectories
+   should only contain function definition files. This allows for frameworks to
+   correctly link:http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions[zcompile all functions].
+   It should not add its root directory to `$fpath`. For the same reason, plugin
+   managers should not add a plugin's root directory to `$fpath` either.
+
+The second point allows plugins to provide completions and functions that are
 loaded via Zsh’s `autoload` mechanism (a single function per-file).
 
 From a more broad perspective, a plugin consists of:


### PR DESCRIPTION
All files in `$fpath` directories should be able to be compiled, as we can see in the [zrecompile doc](http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Recompiling-Functions):

>The following shell loop is an example of a method for creating function digests for all functions in your `fpath`, assuming that you have write permission to the directories:
>
>```
>for ((i=1; i <= $#fpath; ++i)); do
>  dir=$fpath[i]
>  zwc=${dir:t}.zwc
>  if [[ $dir == (.|..) || $dir == (.|..)/* ]]; then
>    continue
>  fi
>  files=($dir/*(N-.))
>  if [[ -w $dir:h && -n $files ]]; then
>    files=(${${(M)files%/*/*}#/})
>    if ( cd $dir:h &&
>         zrecompile -p -U -z $zwc $files ); then
>      fpath[i]=$fpath[i].zwc
>    fi
>  fi
>done
>```

so we can take advantage of compiled function digest files, as explained in the [autoload doc](http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions):

>For each *element* in `fpath`, the shell looks for three possible files, the newest of which is used to load the definition for the function:
>
>`element.zwc`
>
>A file created with the `zcompile` builtin command, which is expected to contain the definitions for all functions in the directory named *element*. The file is treated in the same manner as a directory containing files for functions and is searched for the definition of the function. If the definition is not found, the search for a definition proceeds with the other two possibilities described below.
>
>...

If we added the root of a plugin directory to `$fpath`, we would also allow:
```
% autoload -Uz LICENSE
% LICENSE
LICENSE:21: parse error near `)'
```

I'm not saying this cannot be done, but it does not seem to be something that should be recommended as a good practice in a Standards document.